### PR TITLE
Don't run goreleaser on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     # run only against tags
     tags:


### PR DESCRIPTION
#### Why we need this PR
goreleaser was triggered on PRs, always fails and doesn't make sense

#### Changes made
Don't run goreleaser on PRs
