### PR TITLE
Re-enable win and mac builds

### DIFF
--- a/findIndexImage/.goreleaser.yaml
+++ b/findIndexImage/.goreleaser.yaml
@@ -21,8 +21,8 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      #- windows
-      #- darwin
+      - windows
+      - darwin
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
#### Why we need this PR
Missing win and mac builds

#### Changes made
Fixed goreleaser config
