### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: findIndexImage/go.mod
       - name: Install binaryen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
#### Why we need this PR
Modernize GitHub Actions to current stable versions.

#### Changes made
- Bump `actions/checkout` from v4 to v6
- Bump `actions/setup-go` from v5 to v6
- Update runner image from ubuntu-latest to ubuntu-24.04

#### Which issue(s) this PR fixes
Contributes to [RHWA-852](https://redhat.atlassian.net/browse/RHWA-852) and [RHWA-853](https://redhat.atlassian.net/browse/RHWA-853)

#### Test plan
- CI pre-submit passes with updated action versions