### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: findIndexImage/go.mod
       - name: Install binaryen


### PR DESCRIPTION
#### Why we need this PR

Update outdated GitHub Actions versions to latest majors for security and compatibility.

#### Changes made

- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6

#### Which issue(s) this PR fixes

[RHWA-852](https://issues.redhat.com/browse/RHWA-852)

#### Test plan

- This workflow only triggers on tag pushes, so CI won't run on the PR itself
- Verified that v6 of both actions exists and is compatible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD tooling versions for build and deployment processes.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->