### PR TITLE
Add OWNERS and OWNERS_ALIASES files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    reviewers:
+      - code-reviewers
+    approvers:
+      - approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  approvers:
+      - razo7
+      - mshitrit
+      - slintes
+      - beekhof
+      - clobrano
+
+  code-reviewers:
+      - razo7
+      - mshitrit
+      - slintes
+      - beekhof
+      - clobrano


### PR DESCRIPTION
#### Why we need this PR

The repo is missing OWNERS/OWNERS_ALIASES files, which prevents Prow from processing `/approve` commands. This blocks merging of PRs like #18.

#### Changes made

- Added `OWNERS` file using team aliases pattern (matching FAR, NHC, must-gather, node-remediation-console)
- Added `OWNERS_ALIASES` with the standard medik8s team members

#### Which issue(s) this PR fixes

Unblocks [PR #18](https://github.com/medik8s/tools/pull/18) and future PRs.

#### Test plan

- After merge, verify `/approve` works on PR #18